### PR TITLE
attack preview: show damage and percent sign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.blend1
 *.blend2
 *~
+.idea

--- a/client/GUI.py
+++ b/client/GUI.py
@@ -966,7 +966,7 @@ class ActionPreview(DirectObject.DirectObject):
         self.ctbar.setTransparency(True)
 
         infos = [
-            { 'x':  16, 'z':  23, 'text':  '%02d' % chance        , 'font':   whitefont },
+            { 'x': -25, 'z':  23, 'text': '-%03d Hp     %02d%%' % (damages, chance), 'font':   whitefont },
             { 'x':  15, 'z':   9, 'text':  '%03d' % char1['hp']   , 'font':   whitefont },
             { 'x':  28, 'z':   5, 'text': '/%03d' % char1['hpmax'], 'font':   whitefont },
             { 'x':  15, 'z':  -2, 'text':  '%03d' % char1['mp']   , 'font':   whitefont },


### PR DESCRIPTION
- Adds HP damage and '%' sign to attack preview top-line text. (Not sure if you're still maintaining this project at all, but I came across it looking for open-source FFT/TRPG clients and yours is the only respectable one I've found. Beautifully done. This is just the first thing I came across and wanted to try a quick fix for.)
- rough reference: http://lparchive.org/Final-Fantasy-Tactics/Update%2001/67-capture_25122010_232646.png
